### PR TITLE
feat(seo): add missing meta tags, JSON-LD schema, canonical, and sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.alexandretrotel.org/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,8 +1,9 @@
 export const SITE = {
   baseUrl: "https://www.alexandretrotel.org",
-  title: "Alexandre Trotel | Prediction Markets & TypeScript",
+  title: "Alexandre Trotel | Founder & Open Source Developer",
   description:
     "Co-founder of Radion, the intelligence layer for prediction markets, and Zap Studio, a suite of type-safe TypeScript utilities for real workflows.",
   ogImage: "https://www.alexandretrotel.org/logo.png",
   github: "https://github.com/alexandretrotel",
+  twitter: "https://x.com/alexandretrotel",
 } as const;

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,8 @@
 export const SITE = {
   baseUrl: "https://www.alexandretrotel.org",
+  title: "Alexandre Trotel | Prediction Markets & TypeScript",
   description:
-    "Building tools for complex systems, open source software, and prediction market intelligence.",
-  title: "Alexandre Trotel",
+    "Co-founder of Radion, the intelligence layer for prediction markets, and Zap Studio, a suite of type-safe TypeScript utilities for real workflows.",
+  ogImage: "https://www.alexandretrotel.org/logo.png",
+  github: "https://github.com/alexandretrotel",
 } as const;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -11,7 +11,7 @@ const personSchema = {
   "@type": "Person",
   name: "Alexandre Trotel",
   url: SITE.baseUrl,
-  sameAs: [SITE.github],
+  sameAs: [SITE.github, SITE.twitter],
   jobTitle: "Founder & Developer",
   description: SITE.description,
 };
@@ -30,6 +30,7 @@ export const Route = createRootRoute({
       { property: "og:description", content: SITE.description },
       { property: "og:image", content: SITE.ogImage },
       { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:creator", content: "@alexandretrotel" },
       { name: "twitter:title", content: SITE.title },
       { name: "twitter:description", content: SITE.description },
       { name: "twitter:image", content: SITE.ogImage },

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,16 @@ import { SITE } from "~/lib/site";
 
 import globalsCss from "~/styles/app.css?url";
 
+const personSchema = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Alexandre Trotel",
+  url: SITE.baseUrl,
+  sameAs: [SITE.github],
+  jobTitle: "Founder & Developer",
+  description: SITE.description,
+};
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -15,18 +25,24 @@ export const Route = createRootRoute({
       { name: "description", content: SITE.description },
       { property: "og:type", content: "website" },
       { property: "og:locale", content: "en_US" },
+      { property: "og:site_name", content: "Alexandre Trotel" },
       { property: "og:title", content: SITE.title },
       { property: "og:description", content: SITE.description },
+      { property: "og:image", content: SITE.ogImage },
+      { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: SITE.title },
       { name: "twitter:description", content: SITE.description },
+      { name: "twitter:image", content: SITE.ogImage },
     ],
     links: [
       { rel: "stylesheet", href: globalsCss },
       { rel: "icon", type: "image/png", href: "/logo.png" },
+      { rel: "sitemap", type: "application/xml", href: "/sitemap.xml" },
+    ],
+    scripts: [
       {
-        rel: "sitemap",
-        type: "application/xml",
-        href: "/sitemap.xml",
+        type: "application/ld+json",
+        children: JSON.stringify(personSchema),
       },
     ],
   }),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ export const Route = createFileRoute("/")({
       { name: "twitter:title", content: SITE.title },
       { name: "twitter:description", content: SITE.description },
     ],
+    links: [{ rel: "canonical", href: SITE.baseUrl }],
   }),
   component: Home,
 });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -144,14 +144,15 @@
 @media (prefers-reduced-motion: no-preference) {
   .stagger-item {
     animation: stagger-in 500ms cubic-bezier(0.23, 1, 0.32, 1) both;
+    animation-delay: 500ms;
   }
 
   .stagger-item:nth-child(2) {
-    animation-delay: 300ms;
+    animation-delay: 800ms;
   }
 
   .stagger-item:nth-child(3) {
-    animation-delay: 600ms;
+    animation-delay: 1100ms;
   }
 
   .animate-logo {


### PR DESCRIPTION
## Summary

- Rewrite title/description with keyword-targeted copy (51-char title, 146-char description)
- Add `og:image`, `og:site_name`, `twitter:card`, `twitter:image` — previously missing, breaking social share previews
- Add Person JSON-LD structured data schema with `sameAs` GitHub link
- Add `<link rel="canonical">` on index route
- Create `public/sitemap.xml` — referenced in `robots.txt` but the file didn't exist

## Copy changes

| | Before | After |
|---|---|---|
| Title | `Alexandre Trotel` | `Alexandre Trotel \| Prediction Markets & TypeScript` |
| Description | `Building tools for complex systems, open source software, and prediction market intelligence.` | `Co-founder of Radion, the intelligence layer for prediction markets, and Zap Studio, a suite of type-safe TypeScript utilities for real workflows.` |

## Test plan

- [ ] Validate OG tags with [opengraph.xyz](https://www.opengraph.xyz) after deploy
- [ ] Validate JSON-LD with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Confirm `https://www.alexandretrotel.org/sitemap.xml` resolves after deploy
- [ ] Submit sitemap to Google Search Console